### PR TITLE
Decouple & make all return types basic types

### DIFF
--- a/timer.go
+++ b/timer.go
@@ -17,13 +17,6 @@ type Timer struct {
 	labels  []string
 }
 
-// RunningTimer keeps track of timer times
-type RunningTimer struct {
-	Base  *Timer
-	start time.Time
-	end   time.Time
-}
-
 func newTimer(namespace, subsystem, name string, labelNames []string, client *statsd.Statter) *Timer {
 	opts := prometheus.HistogramOpts{
 		Namespace: namespace,
@@ -41,45 +34,42 @@ func newTimer(namespace, subsystem, name string, labelNames []string, client *st
 }
 
 // RunWithError gets a function with error and lables and run it with measurment
-func (w *Timer) RunWithError(work func() error, labelValues ...string) error {
+func (t *Timer) RunWithError(work func() error, labelValues ...string) error {
 	start := time.Now()
 	err := work()
 	end := time.Now()
-	if indx := w.hasLabel("ok"); indx > 0 {
+	if indx := t.hasLabel("ok"); indx > 0 {
 		labelValues[indx] = fmt.Sprint(err == nil)
 	}
-	w.register(start, end, labelValues)
+	t.register(start, end, labelValues)
 	return err
 }
 
 // RunVoid gets a void function and lables and run it with measurment
-func (w *Timer) RunVoid(work func(), labelValues ...string) {
+func (t *Timer) RunVoid(work func(), labelValues ...string) {
 	start := time.Now()
 	work()
 	end := time.Now()
-	w.register(start, end, labelValues)
+	t.register(start, end, labelValues)
 }
 
 // Start begins a RunningTimer and then returns it
-func (w *Timer) Start() *RunningTimer {
-	return &RunningTimer{
-		Base:  w,
-		start: time.Now(),
-	}
+func (w *Timer) Start() time.Time {
+	return time.Now()
 }
 
 // Done finalize the current RunningTimer
-func (rt *RunningTimer) Done(labelValues ...string) {
-	rt.end = time.Now()
-	rt.Base.register(rt.start, rt.end, labelValues)
+func (t *Timer) Done(start time.Time, labelValues ...string) {
+	end := time.Now()
+	t.register(start, end, labelValues)
 }
 
-func (w *Timer) register(start time.Time, end time.Time, labelValues []string) {
+func (t *Timer) register(start time.Time, end time.Time, labelValues []string) {
 	duration := end.Sub(start)
-	w.watcher.WithLabelValues(labelValues...).Observe(duration.Seconds())
-	metaLabel := w.prefix + "." + strings.Join(labelValues, ".")
-	(*w.client).Timing(metaLabel, int64(duration/time.Millisecond), 1.0)
-	(*w.client).Inc(metaLabel, 1, 1.0)
+	t.watcher.WithLabelValues(labelValues...).Observe(duration.Seconds())
+	metaLabel := t.prefix + "." + strings.Join(labelValues, ".")
+	(*t.client).Timing(metaLabel, int64(duration/time.Millisecond), 1.0)
+	(*t.client).Inc(metaLabel, 1, 1.0)
 }
 
 func (w *Timer) hasLabel(label string) int {

--- a/timer_with_counter.go
+++ b/timer_with_counter.go
@@ -1,6 +1,8 @@
 package epimetheus
 
 import (
+	"time"
+
 	"github.com/cactus/go-statsd-client/statsd"
 )
 
@@ -8,14 +10,6 @@ import (
 type TimerWithCounter struct {
 	*Timer
 	*Counter
-}
-
-// RunningTimerWithCounter consists of a RunningTimer and a TimerWithCounter
-//
-// Calling `Done` on the instance which returned by `TimerWithCounter.Start` finalize the operation
-type RunningTimerWithCounter struct {
-	runningTimer     *RunningTimer
-	timerWithCounter *TimerWithCounter
 }
 
 func newTimerWithCounter(namespace, subsystem, name string, labelNames []string, client *statsd.Statter) *TimerWithCounter {
@@ -28,15 +22,12 @@ func newTimerWithCounter(namespace, subsystem, name string, labelNames []string,
 }
 
 // Start creates an instance of `RunningTimerWithCounter` and returns it
-func (w *TimerWithCounter) Start() *RunningTimerWithCounter {
-	return &RunningTimerWithCounter{
-		runningTimer:     w.Timer.Start(),
-		timerWithCounter: w,
-	}
+func (tc *TimerWithCounter) Start() time.Time {
+	return tc.Timer.Start()
 }
 
 // Done marks the related timer as done and increments the related counter too
-func (rt *RunningTimerWithCounter) Done(labelValues ...string) {
-	rt.runningTimer.Done(labelValues...)
-	rt.timerWithCounter.Counter.Inc(labelValues...)
+func (tc *TimerWithCounter) Done(start time.Time, labelValues ...string) {
+	tc.Timer.Done(start, labelValues...)
+	tc.Counter.Inc(labelValues...)
 }


### PR DESCRIPTION
**Breaking Change** :
On timers, `Done` has to be called on the original timer object but with an extra input now.